### PR TITLE
add parents and parents/:until endpoints

### DIFF
--- a/pkg/api/v1/pagination.go
+++ b/pkg/api/v1/pagination.go
@@ -75,6 +75,10 @@ func (p *PaginationParams) offset() int {
 	return (p.page() - 1) * p.limitUsed()
 }
 
+func (p *PaginationParams) getPageOffset() int {
+	return p.limitUsed() * (p.page() - 1)
+}
+
 func (p *PaginationParams) queryMods() []qm.QueryMod {
 	var mods []qm.QueryMod
 

--- a/pkg/api/v1/responses.go
+++ b/pkg/api/v1/responses.go
@@ -27,8 +27,9 @@ func v1TenantCreatedResponse(c echo.Context, t *models.Tenant) error {
 
 func v1TenantsResponse(c echo.Context, ts []*models.Tenant, pagination PaginationParams) error {
 	return c.JSON(http.StatusOK, v1TenantSliceResponse{
-		Tenants: v1TenantSlice(ts),
-		Version: apiVersion,
+		Tenants:          v1TenantSlice(ts),
+		Version:          apiVersion,
+		PaginationParams: pagination,
 	})
 }
 

--- a/pkg/api/v1/router.go
+++ b/pkg/api/v1/router.go
@@ -70,6 +70,9 @@ func (r *Router) Routes(e *echo.Group) {
 
 		v1.GET("/tenants/:id/tenants", r.tenantList)
 		v1.POST("/tenants/:id/tenants", r.tenantCreate)
+
+		v1.GET("/tenants/:id/parents", r.tenantParentsList)
+		v1.GET("/tenants/:id/parents/:parent_id", r.tenantParentsList)
 	}
 
 	_, err := r.pubsub.AddStream()


### PR DESCRIPTION
This allows for all parents to be retrieved or only up to a specific parent uuid.

A raw SQL query was used to solve N+1 inefficiency.