### PR TITLE
Add sshd feature to dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/vscode/devcontainers/go:0-1.20-bullseye
 
 # [Optional] Uncomment this section to install additional OS packages.
 RUN export DEBIAN_FRONTEND=noninteractive \
-    && curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg \
+    && curl https://baltocdn.com/helm/signing.asc | gpg --dearmor > /usr/share/keyrings/helm.gpg \
     &&  curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor > /usr/share/keyrings/yarn-archive-keyring.gpg \
     && apt-get install apt-transport-https --yes \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,13 +25,8 @@
 			]
 		}
 	},
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [8081, 8090, 1234],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "go version",
-
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode"
+	"remoteUser": "vscode",
+	"features": {
+		"ghcr.io/devcontainers/features/sshd:1": {}
+	}
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -17,6 +17,9 @@ services:
         NODE_VERSION: "none"
     command:
       - .devcontainer/scripts/app-entrypoint.sh
+    # uncomment along with bind volume to use SSH for dev container access
+    #ports:
+    #  - "127.0.0.1:2225:2222"
     env_file:
       - .env
       - .go.env
@@ -24,6 +27,10 @@ services:
       - ./nsc:/nsc
       - ..:/workspace:cached
       - audit:/app-audit
+      #- type: bind
+      #  source: ~/.ssh/authorized_keys
+      #  target: /home/vscode/.ssh/authorized_keys
+      #  read_only: true
     networks:
       - infradev
     depends_on:


### PR DESCRIPTION
This PR adds support for the sshd feature to the dev container. Enabling this allows the dev container to be accessed via SSH directly (useful for non-VS Code environments).

Additionally, this PR fixes an issue in retrieving the Helm signing key that was causing the signing key to be printed directly to the terminal, causing various problems.