### PR TITLE
correct service monitor endpoint port

### DIFF
--- a/chart/tenant-api/templates/serviceMonitor.yaml
+++ b/chart/tenant-api/templates/serviceMonitor.yaml
@@ -9,5 +9,5 @@ spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
   endpoints:
-    - port: web
+    - port: http
 {{- end }}


### PR DESCRIPTION
Corrects a bad copy paste from identity service which has it's port named `web` instead of `http`.