### PR TITLE
Add support for OpenTelemetry to Helm chart

### DIFF
--- a/chart/tenant-api/templates/deployment.yaml
+++ b/chart/tenant-api/templates/deployment.yaml
@@ -64,6 +64,28 @@ spec:
               value: ":{{ .Values.api.listenPort }}"
             - name: TENANTAPI_SERVER_SHUTDOWN_GRACE_PERIOD
               value: "{{ .Values.api.shutdownGracePeriod }}"
+            - name: TENANTAPI_TRACING_ENABLED
+              value: "{{ .Values.api.tracing.enabled }}"
+            - name: TENANTAPI_TRACING_PROVIDER
+              value: "{{ .Values.api.tracing.provider }}"
+            - name: TENANTAPI_TRACING_ENVIRONMENT
+              value: "{{ .Values.api.tracing.environment }}"
+          {{- if eq .Values.api.tracing.provider "jaeger" }}
+            - name: TENANTAPI_TRACING_JAEGER_ENDPOINT
+              value: "{{ .Values.api.tracing.jaeger.endpoint }}"
+            - name: TENANTAPI_TRACING_JAEGER_USER
+              value: "{{ .Values.api.tracing.jaeger.user }}"
+            - name: TENANTAPI_TRACING_JAEGER_PASSWORD
+              value: "{{ .Values.api.tracing.jaeger.password }}"
+          {{- end }}
+          {{- if eq .Values.api.tracing.provider "otlpgrpc" }}
+            - name: TENANTAPI_TRACING_OTLP_ENDPOINT
+              value: "{{ .Values.api.tracing.otlp.endpoint }}"
+            - name: TENANTAPI_TRACING_OTLP_INSECURE
+              value: "{{ .Values.api.tracing.otlp.insecure }}"
+            - name: TENANTAPI_TRACING_OTLP_CERTIFICATE
+              value: "{{ .Values.api.tracing.otlp.certificate }}"
+          {{- end }}
           {{- with .Values.api.trustedProxies }}
             - name: TENANTAPI_SERVER_TRUSTED_PROXIES
               value: "{{ join " " . }}"

--- a/chart/tenant-api/values.yaml
+++ b/chart/tenant-api/values.yaml
@@ -68,6 +68,25 @@ api:
   # - "1.2.3.4/32"
   # - "1.2.3.0/24"
 
+  tracing:
+    # enabled is true if OpenTelemetry tracing should be enabled for permissions-api
+    enabled: false
+    # environment is the OpenTelemetry tracing environment to use
+    environment: ""
+    # provider is the OpenTelemetry tracing provider to use
+    provider: stdout
+    jaeger:
+      # endpoint is the Jaeger collector to send traces to
+      endpoint: ""
+      # user is the user to use when authenticating against the Jaeger deployment
+      user: ""
+      # password is the password to use when authenticating against the Jaeger deployment
+      password: ""
+    otlp:
+      # endpoint is the OpenTelemetry Protocol (OTLP) collector endpoint to send traces to
+      endpoint: ""
+      # insecure is true if TLS should not be required when sending traces
+      insecure: false
 
 serviceMonitor:
   enabled: false


### PR DESCRIPTION
tenant-api has OpenTelemetry support, but the Helm chart does not take advantage of this. This PR adds OpenTelemetry tracing options to the tenant-api Helm chart.