### PR TITLE
Pin go to 1.20.5 for tests

### DIFF
--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -45,6 +45,8 @@ jobs:
       - name: Set up Go for ${{ matrix.ci-database }}
         uses: actions/setup-go@v4
         with:
-          go-version-file: "go.mod"
+          #pinning to 1.20.5 until https://github.com/testcontainers/testcontainers-go/issues/1359 is resolved
+          #go-version-file: "go.mod"
+          go-version: "1.20.5"
       - name: Run go tests for ${{ matrix.ci-database }}
         run: TENANTAPI_TESTDB_URI="${{ matrix.env-database-uri }}" go test -race -coverprofile=coverage.txt -covermode=atomic -tags testtools ./...


### PR DESCRIPTION
There is a current bug somewhere in the mix of go 1.26 <- Moby -> testcontainers. This is being worked out in https://github.com/testcontainers/testcontainers-go/issues/1359 . Until this is fixed, the workaround seems to be pinning to go 1.20.5 for testing