### PR TITLE
update runtime configmap to manifests as defined in v0.5.0 release

### DIFF
--- a/chart/tenant-api/templates/deployment.yaml
+++ b/chart/tenant-api/templates/deployment.yaml
@@ -178,4 +178,4 @@ spec:
           secret:
             secretName: "{{ .Values.api.db.certSecret }}"
         {{- end }}
-{{- include "iam-runtime-infratographer.configmap" $ }}
+{{- include "iam-runtime-infratographer.manifests" $ }}


### PR DESCRIPTION
Somehow this commit didn't get pushed. This corrects the helm chart to use the updated `iam-runtime-infratographer.manifests` function as defined in the v0.5.0 release of the `iam-runtime-infratographer` chart.